### PR TITLE
debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ if (isMatch > 0.95) {
 }
 ```
 
-
 ### add
 
 Add accepts a new street represented as a GeoJSON LineString Feature with properties representing a metadata blob. The add function should be used when a proposed street has a low match score, signifying an edge that is not represented in the existing graph. The graph will be incrementally normalized to maintain topological integrity, and may result in one or more edges being added to the graph.

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,3 @@
+module.exports = function(obj) {
+  console.log(JSON.stringify(obj));
+};

--- a/src/index.js
+++ b/src/index.js
@@ -200,6 +200,10 @@ Mashnet.prototype.scan = function(addition) {
     }
     if (boxes.length) {
       debug({
+        type: "fit",
+        bbox: turf.bbox(turf.multiLineString(boxes))
+      });
+      debug({
         type: "draw",
         geometry: turf.multiLineString(boxes).geometry,
         style: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ const turf = require("@turf/turf");
 
 const Mashnet = require("../src/index.js");
 
-test("mashnet - scan", async t => {
+test("mashnet", async t => {
   const honolulu = require(path.join(__dirname, "../samples/honolulu.json"));
 
   var net = new Mashnet(honolulu);
@@ -21,10 +21,15 @@ test("mashnet - scan", async t => {
       ]
     }
   };
+
+  // scan
+
   var scores = net.scan(addition);
 
   t.ok(scores.length > 0, "found matches");
   t.equal(scores[0].line.type, "Feature", "result contains matched feature");
+
+  // match
 
   const isMatch = net.match(scores);
 
@@ -34,14 +39,36 @@ test("mashnet - scan", async t => {
     max_speed: 70
   };
 
+  // merge
+
   net.merge(scores[0].id, metadata);
 
-  const edge = net.metadata.get(scores[0].id);
+  const data = net.metadata.get(scores[0].id);
   t.equal(
-    JSON.stringify(edge),
+    JSON.stringify(data),
     '{"highway":"residential","name":"Ala Akulikuli Street","max_speed":70}',
     "metadata merged"
   );
+
+  // add
+
+  var street = {
+    type: "Feature",
+    properties: {},
+    geometry: {
+      type: "LineString",
+      coordinates: [
+        [-157.91604816913605, 21.35034147982776],
+        [-157.91581213474274, 21.35018409732726],
+        [-157.91565924882886, 21.350114149495003],
+        [-157.91538298130035, 21.349984246289427],
+        [-157.9150503873825, 21.34975441725907],
+        [-157.91475266218185, 21.349584543396308]
+      ]
+    }
+  };
+
+  net.add(street);
 
   t.done();
 });

--- a/utils/debugger.html
+++ b/utils/debugger.html
@@ -29,6 +29,7 @@
 <script>
   const DELTA = 75;
   const STEP = 200;
+	const BOUNDS_BORDER = 0.5
   var display = [];
 	mapboxgl.accessToken = '{{token}}';
   var map = new mapboxgl.Map({
@@ -136,7 +137,12 @@
         const action = actions.shift()
 
         if (action.type === 'fit') {
-          map.fitBounds([action.bbox.slice(0,2), action.bbox.slice(2,4)])
+					const borderX = (action.bbox[2] - action.bbox[0]) * BOUNDS_BORDER
+					const borderY = (action.bbox[3] - action.bbox[1]) * BOUNDS_BORDER
+
+          map.fitBounds([[action.bbox[0]-borderX, action.bbox[1]-borderY],
+						[action.bbox[2]+borderX, action.bbox[3]+borderY]
+					])
         } else if (action.type === 'draw') {
           data[action.geometry.type].features.push({
             'type': 'Feature',

--- a/utils/debugger.html
+++ b/utils/debugger.html
@@ -29,7 +29,7 @@
 <script>
   const DELTA = 75;
   const STEP = 200;
-	const BOUNDS_BORDER = 0.5
+	const BOUNDS_BORDER = 0.2
   var display = [];
 	mapboxgl.accessToken = '{{token}}';
   var map = new mapboxgl.Map({

--- a/utils/debugger.html
+++ b/utils/debugger.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>mashnet</title>
+<meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+<script src="https://api.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.js"></script>
+<link href="https://api.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.css" rel="stylesheet" />
+<style>
+	body { margin: 0; padding: 0; }
+	#map {
+    position: absolute; top: 0; bottom: 0; width: 100%; z-index: -1;
+  }
+
+  #log {
+    position: relative;
+    z-index: 99;
+    padding: 50px;
+    background-color: transparent;
+    pointer-events: none;
+    font-family: "Courier New", Courier, monospace;
+    font-size: 25px;
+  }
+</style>
+</head>
+<body>
+<div id="log"></div>
+<div id="map"></div>
+<script>
+  const DELTA = 75;
+  const STEP = 200;
+  var display = [];
+	mapboxgl.accessToken = '{{token}}';
+  var map = new mapboxgl.Map({
+      container: 'map',
+      style: 'mapbox://styles/mapbox/dark-v10',
+      center: [-157.85924434661865,
+          21.30142986366899],
+      zoom: 12
+  });
+
+  var data = reset()
+
+  var actions = {{actions}}
+  const copy = JSON.parse(JSON.stringify(actions))
+
+  var current = STEP
+  map.on('load', () => {
+    map.addLayer({
+      'id': 'Polygon',
+      'type': 'fill',
+      'source': {
+        'type': 'geojson',
+        'data': data['Polygon']
+      },
+      'paint': {
+        'fill-color': ['get', 'color'],
+        'fill-opacity': ['get', 'opacity']
+      }
+    })
+    map.addLayer({
+      'id': 'MultiPolygon',
+      'type': 'fill',
+      'source': {
+        'type': 'geojson',
+        'data': data['MultiPolygon']
+      },
+      'paint': {
+        'fill-color': ['get', 'color'],
+        'fill-opacity': ['get', 'opacity']
+      }
+    })
+    map.addLayer({
+      'id': 'LineString',
+      'type': 'line',
+      'source': {
+        'type': 'geojson',
+        'data': data['LineString']
+      },
+      'paint': {
+        'line-width': ['get', 'width'],
+        'line-color': ['get', 'color'],
+        'line-opacity': ['get', 'opacity']
+      }
+    })
+    map.addLayer({
+      'id': 'MultiLineString',
+      'type': 'line',
+      'source': {
+        'type': 'geojson',
+        'data': data['MultiLineString']
+      },
+      'paint': {
+        'line-width': ['get', 'width'],
+        'line-color': ['get', 'color'],
+        'line-opacity': ['get', 'opacity']
+      }
+    })
+    map.addLayer({
+      'id': 'Point',
+      'type': 'circle',
+      'source': {
+        'type': 'geojson',
+        'data': data['Point']
+      },
+      'paint': {
+        'circle-radius': ['get', 'width'],
+        'circle-color': ['get', 'color'],
+        'circle-opacity': ['get', 'opacity']
+      }
+    })
+    map.addLayer({
+      'id': 'MultiPoint',
+      'type': 'circle',
+      'source': {
+        'type': 'geojson',
+        'data': data['MultiPoint']
+      },
+      'paint': {
+        'circle-radius': ['get', 'width'],
+        'circle-color': ['get', 'color'],
+        'circle-opacity': ['get', 'opacity']
+      }
+    })
+
+    setInterval(() => {
+      if (actions.length === 0) {
+        display = []
+        data = reset()
+        actions = JSON.parse(JSON.stringify(copy))
+      }
+
+      current = current - DELTA;
+      if (current <= 0) {
+        current = STEP
+        const action = actions.shift()
+
+        if (action.type === 'fit') {
+          map.fitBounds([action.bbox.slice(0,2), action.bbox.slice(2,4)])
+        } else if (action.type === 'draw') {
+          data[action.geometry.type].features.push({
+            'type': 'Feature',
+            'geometry': action.geometry,
+            'properties': action.style,
+            'opacity': action.style.opacity,
+            'fade': action.fade || -1,
+            'age': 0
+          })
+        } else if (action.type === 'log') {
+          if (display.length > 10) {
+            display = display.slice(1, display.length)
+          }
+          if(!action.color) action.color = '#fff'
+          display.push(action)
+
+          document.getElementById('log').innerHTML =
+            display.map(action => {
+              return '<div style="color:'+action.color+';"><span style="padding:2.8px;background-color:rgba(10,10,10,0.4);">' + action.message + '</span></div>'
+            }).join('');
+        } else if (action.type === 'clear') {
+          display = []
+          data = reset()
+        }
+      }
+
+      // render
+      for (let type of Object.keys(data)) {
+        var filtered = {
+          'type': 'FeatureCollection',
+          'features': []
+        }
+        for (let feature of data[type].features) {
+          feature.age += DELTA
+          if (feature.fade === -1) {
+            filtered.features.push(feature)
+          } else {
+            if (feature.age >= feature.fade) {
+              // omit faded features
+            } else {
+              feature.properties.opacity =
+                feature.opacity - (feature.opacity * (feature.age / feature.fade))
+              filtered.features.push(feature)
+            }
+          }
+        }
+        data[type] = filtered;
+        map.getSource(type).setData(data[type]);
+      }
+    }, DELTA)
+  })
+
+  function reset () {
+    return {
+      'Point': {
+        'type': 'FeatureCollection',
+        'features': []
+      },
+      'MultiPoint': {
+        'type': 'FeatureCollection',
+        'features': []
+      },
+      'LineString': {
+        'type': 'FeatureCollection',
+        'features': []
+      },
+      'MultiLineString': {
+        'type': 'FeatureCollection',
+        'features': []
+      },
+      'Polygon': {
+        'type': 'FeatureCollection',
+        'features': []
+      },
+      'MultiPolygon': {
+        'type': 'FeatureCollection',
+        'features': []
+      }
+    }
+  }
+</script>
+
+</body>
+</html>

--- a/utils/debugger.js
+++ b/utils/debugger.js
@@ -16,6 +16,9 @@ var actions = fs
     return line.length;
   })
   .map(JSON.parse);
+/*.filter(line => {
+    return line.type !== 'log';
+  });*/
 
 var render = html
   .split("{{token}}")

--- a/utils/debugger.js
+++ b/utils/debugger.js
@@ -1,0 +1,26 @@
+// node debug-map.js ./actions.json ./animation.html
+
+const fs = require("fs");
+const path = require("path");
+
+var html = fs.readFileSync(path.join(__dirname, "debugger.html")).toString();
+
+var token =
+  "pk.eyJ1IjoibW9yZ2FuaGVybG9ja2VyIiwiYSI6Ii1zLU4xOWMifQ.FubD68OEerk74AYCLduMZQ";
+
+var actions = fs
+  .readFileSync(process.argv[2])
+  .toString()
+  .split("\n")
+  .filter(line => {
+    return line.length;
+  })
+  .map(JSON.parse);
+
+var render = html
+  .split("{{token}}")
+  .join(token)
+  .split("{{actions}}")
+  .join(JSON.stringify(actions));
+
+fs.writeFileSync(process.argv[3], render);

--- a/utils/demo.js
+++ b/utils/demo.js
@@ -24,6 +24,7 @@ var addition = {
 
 var scores = net.scan(addition);
 
+/*
 // match
 
 const isMatch = net.match(scores);
@@ -57,3 +58,4 @@ var street = {
 };
 
 net.add(street);
+*/

--- a/utils/demo.js
+++ b/utils/demo.js
@@ -1,0 +1,59 @@
+const path = require("path");
+const turf = require("@turf/turf");
+
+const Mashnet = require("../src/index.js");
+
+const honolulu = require(path.join(__dirname, "../samples/honolulu.json"));
+
+var net = new Mashnet(honolulu);
+
+var addition = {
+  type: "Feature",
+  properties: {},
+  geometry: {
+    type: "LineString",
+    coordinates: [
+      [-157.9146158695221, 21.346424354025306],
+      [-157.9154634475708, 21.347043906401122],
+      [-157.9165470600128, 21.348442886005444]
+    ]
+  }
+};
+
+// scan
+
+var scores = net.scan(addition);
+
+// match
+
+const isMatch = net.match(scores);
+
+const metadata = {
+  max_speed: 70
+};
+
+// merge
+
+net.merge(scores[0].id, metadata);
+
+const data = net.metadata.get(scores[0].id);
+
+// add
+
+var street = {
+  type: "Feature",
+  properties: {},
+  geometry: {
+    type: "LineString",
+    coordinates: [
+      [-157.91604816913605, 21.35034147982776],
+      [-157.91581213474274, 21.35018409732726],
+      [-157.91565924882886, 21.350114149495003],
+      [-157.91538298130035, 21.349984246289427],
+      [-157.9150503873825, 21.34975441725907],
+      [-157.91475266218185, 21.349584543396308]
+    ]
+  }
+};
+
+net.add(street);


### PR DESCRIPTION
This PR adds debug output following the [mapdeduce](https://github.com/morganherlocker/mapdeduce) animation format. This allows each of the internal steps of the algorithms used in mashnet to be understood visually.

![mashnet-2](https://user-images.githubusercontent.com/814300/73228566-d3bd0200-412b-11ea-8680-0fe7431b77fa.gif)

Outputting animation data will cause a performance hit, so this feature is entirely optional. To enable, add DEBUG=1 env variable when running a mashnet script in node. For example:

```sh
DEBUG=1 node merge-network.js > debug.json
```

There is still some work to do in selecting what to visualize. I think some of the debug output is a little busy still, and some important parts of the algorithm still need to be added (ie: hausdorf scan comparison).